### PR TITLE
Remove left padding from h3

### DIFF
--- a/css/parts/content.less
+++ b/css/parts/content.less
@@ -25,7 +25,6 @@
     color: lighten(@body_text_color, 10);
     margin-top: 20px;
     margin-bottom: 15px;
-    padding: 0 0 0 10px;
   }
   p, ul, ol { font-size: 16px; line-height: 1.6; color: @body_text_color; }
   code { color: #696969; background: @light; border: 1px solid #f0f0f0; padding: 3px; font-size: 14px; }


### PR DESCRIPTION
The left padding on h3s might exist for some reason, but in most contexts it looks extremely weird and makes the header look out of place. If it needs to have padding on some specific pages, the padding should be added on these pages only.