### PR TITLE
Make nav titles indented & consistent thick nav links

### DIFF
--- a/css/parts/content.less
+++ b/css/parts/content.less
@@ -58,8 +58,8 @@
 
       li a {
         display: block;
-        padding: 5px 1px;
-        padding-top: 6px;
+        padding: 0.5em 0.75em;
+        min-height: 3em;
         font-size: 15px;
         border-bottom: 1px solid #eee;
         color: @text_color;


### PR DESCRIPTION
Makes nav links without an icon as thick as those with one.
![image](https://github.com/user-attachments/assets/d8dee0db-0b07-43a2-bfad-ebb8f650d2c3)
